### PR TITLE
Auto reconnect

### DIFF
--- a/src/core.tsx
+++ b/src/core.tsx
@@ -68,11 +68,7 @@ export function NostrProvider({
   const connectToRelay = async (relayUrl:string) => {
     log(debug, "info", `🚧 initiating connection to (${relayUrl}) ...`)
     const relay = relayInit(relayUrl)
-    try {
-      relay.connect()
-    } catch(err) {
-      console.log(err) 
-    }
+    relay.connect()
 
     relay.on("connect", () => {
       log(debug, "info", `✅ nostr (${relayUrl}): Connected!`)

--- a/src/core.tsx
+++ b/src/core.tsx
@@ -81,6 +81,7 @@ export function NostrProvider({
       log(debug, "warn", `🚪 nostr (${relayUrl}): Connection closed.`)
       onDisconnectCallback?.(relay)
       setConnectedRelays((prev) => prev.filter((r) => r.url !== relayUrl))
+      if (autoReconnect) { connectToRelay(relayUrl); }
     })
 
     relay.on("error", () => {
@@ -112,7 +113,6 @@ export function NostrProvider({
 
   const value: NostrContextType = {
     debug,
-    autoReconnect,
     isLoading,
     connectedRelays,
     publish,
@@ -122,7 +122,6 @@ export function NostrProvider({
       }
     },
     onDisconnect: (_onDisconnectCallback?: OnDisconnectFunc) => {
-      if (autoReconnect) { connectToRelay(relayUrl); }
       if (_onDisconnectCallback) {
         onDisconnectCallback = _onDisconnectCallback
       }

--- a/src/core.tsx
+++ b/src/core.tsx
@@ -91,7 +91,7 @@ export function NostrProvider({
 
   const connectToRelays = useCallback(() => {
     relayUrls.forEach(async (relayUrl) => {
-      await connectToRelay(relayUrl)
+      connectToRelay(relayUrl)
     })
   }, [])
 

--- a/src/core.tsx
+++ b/src/core.tsx
@@ -81,7 +81,6 @@ export function NostrProvider({
       log(debug, "warn", `🚪 nostr (${relayUrl}): Connection closed.`)
       onDisconnectCallback?.(relay)
       setConnectedRelays((prev) => prev.filter((r) => r.url !== relayUrl))
-      if (autoReconnect) { reconnectToRelays(relayUrl); }
     })
 
     relay.on("error", () => {
@@ -113,6 +112,7 @@ export function NostrProvider({
 
   const value: NostrContextType = {
     debug,
+    autoReconnect,
     isLoading,
     connectedRelays,
     publish,
@@ -122,6 +122,7 @@ export function NostrProvider({
       }
     },
     onDisconnect: (_onDisconnectCallback?: OnDisconnectFunc) => {
+      if (autoReconnect) { connectToRelay(relayUrl); }
       if (_onDisconnectCallback) {
         onDisconnectCallback = _onDisconnectCallback
       }

--- a/src/core.tsx
+++ b/src/core.tsx
@@ -71,7 +71,7 @@ export function NostrProvider({
     try {
       relay.connect()
     } catch(err) {
-      console.log(er) 
+      console.log(err) 
     }
 
     relay.on("connect", () => {

--- a/src/core.tsx
+++ b/src/core.tsx
@@ -62,27 +62,32 @@ export function NostrProvider({
 
   const isFirstRender = useRef(true)
 
+  const connectToRelay = async (relayUrl) => {
+    log(debug, "info", `🚧 initiating connection to (${relayUrl}) ...`)
+    const relay = relayInit(relayUrl)
+    relay.connect()
+
+    relay.on("connect", () => {
+      log(debug, "info", `✅ nostr (${relayUrl}): Connected!`)
+      setIsLoading(false)
+      onConnectCallback?.(relay)
+      setConnectedRelays((prev) => uniqBy([...prev, relay], "url"))
+    })
+
+    relay.on("disconnect", () => {
+      log(debug, "warn", `🚪 nostr (${relayUrl}): Connection closed.`)
+      onDisconnectCallback?.(relay)
+      setConnectedRelays((prev) => prev.filter((r) => r.url !== relayUrl))
+    })
+
+    relay.on("error", () => {
+      log(debug, "error", `❌ nostr (${relayUrl}): Connection error!`)
+    })
+  }
+
   const connectToRelays = useCallback(() => {
     relayUrls.forEach(async (relayUrl) => {
-      const relay = relayInit(relayUrl)
-      relay.connect()
-
-      relay.on("connect", () => {
-        log(debug, "info", `✅ nostr (${relayUrl}): Connected!`)
-        setIsLoading(false)
-        onConnectCallback?.(relay)
-        setConnectedRelays((prev) => uniqBy([...prev, relay], "url"))
-      })
-
-      relay.on("disconnect", () => {
-        log(debug, "warn", `🚪 nostr (${relayUrl}): Connection closed.`)
-        onDisconnectCallback?.(relay)
-        setConnectedRelays((prev) => prev.filter((r) => r.url !== relayUrl))
-      })
-
-      relay.on("error", () => {
-        log(debug, "error", `❌ nostr (${relayUrl}): Connection error!`)
-      })
+      await connectToRelay(relayUrl: string)
     })
   }, [])
 

--- a/src/core.tsx
+++ b/src/core.tsx
@@ -87,7 +87,7 @@ export function NostrProvider({
 
   const connectToRelays = useCallback(() => {
     relayUrls.forEach(async (relayUrl) => {
-      await connectToRelay(relayUrl: string)
+      await connectToRelay(relayUrl)
     })
   }, [])
 

--- a/src/core.tsx
+++ b/src/core.tsx
@@ -22,6 +22,7 @@ type OnSubscribeFunc = (sub: Sub, relay: Relay) => void
 interface NostrContextType {
   isLoading: boolean
   debug?: boolean
+  autoReconnect?: boolean
   connectedRelays: Relay[]
   onConnect: (_onConnectCallback?: OnConnectFunc) => void
   onDisconnect: (_onDisconnectCallback?: OnDisconnectFunc) => void
@@ -49,10 +50,12 @@ export function NostrProvider({
   children,
   relayUrls,
   debug,
+  autoReconnect,
 }: {
   children: ReactNode
   relayUrls: string[]
   debug?: boolean
+  autoReconnect?: boolean
 }) {
   const [isLoading, setIsLoading] = useState(true)
   const [connectedRelays, setConnectedRelays] = useState<Relay[]>([])
@@ -78,6 +81,7 @@ export function NostrProvider({
       log(debug, "warn", `🚪 nostr (${relayUrl}): Connection closed.`)
       onDisconnectCallback?.(relay)
       setConnectedRelays((prev) => prev.filter((r) => r.url !== relayUrl))
+      if (autoReconnect) { reconnectToRelays(relayUrl); }
     })
 
     relay.on("error", () => {

--- a/src/core.tsx
+++ b/src/core.tsx
@@ -91,7 +91,7 @@ export function NostrProvider({
 
   const connectToRelays = useCallback(() => {
     relayUrls.forEach(async (relayUrl) => {
-      connectToRelay(relayUrl)
+      await connectToRelay(relayUrl)
     })
   }, [])
 

--- a/src/core.tsx
+++ b/src/core.tsx
@@ -62,7 +62,7 @@ export function NostrProvider({
 
   const isFirstRender = useRef(true)
 
-  const connectToRelay = async (relayUrl) => {
+  const connectToRelay = async (relayUrl:string) => {
     log(debug, "info", `🚧 initiating connection to (${relayUrl}) ...`)
     const relay = relayInit(relayUrl)
     relay.connect()

--- a/src/core.tsx
+++ b/src/core.tsx
@@ -68,11 +68,7 @@ export function NostrProvider({
   const connectToRelay = async (relayUrl:string) => {
     log(debug, "info", `🚧 initiating connection to (${relayUrl}) ...`)
     const relay = relayInit(relayUrl)
-    try {
-      relay.connect()
-    } catch (err) {
-      console.log(err)
-    }
+    relay.connect()
 
     relay.on("connect", () => {
       log(debug, "info", `✅ nostr (${relayUrl}): Connected!`)

--- a/src/core.tsx
+++ b/src/core.tsx
@@ -68,7 +68,11 @@ export function NostrProvider({
   const connectToRelay = async (relayUrl:string) => {
     log(debug, "info", `🚧 initiating connection to (${relayUrl}) ...`)
     const relay = relayInit(relayUrl)
-    relay.connect()
+    try {
+      relay.connect()
+    } catch(err) {
+      console.log(er) 
+    }
 
     relay.on("connect", () => {
       log(debug, "info", `✅ nostr (${relayUrl}): Connected!`)

--- a/src/core.tsx
+++ b/src/core.tsx
@@ -68,7 +68,11 @@ export function NostrProvider({
   const connectToRelay = async (relayUrl:string) => {
     log(debug, "info", `🚧 initiating connection to (${relayUrl}) ...`)
     const relay = relayInit(relayUrl)
-    relay.connect()
+    try {
+      relay.connect()
+    } catch (err) {
+      console.log(err)
+    }
 
     relay.on("connect", () => {
       log(debug, "info", `✅ nostr (${relayUrl}): Connected!`)


### PR DESCRIPTION
Trigger an automatic reconnection attempt whenever a relay disconnects. By default, this functionality is off. Activate it using `autoReconnect` like this:

```
<NostrProvider relayUrls={relayUrls} debug={true} autoReconnect={true} >
  <App />
</NostrProvider>
```

I'm wondering whether I should move the logic for triggering the reconnection attempt to `OnDisconnectFunc`. Let me know if that would make more sense. We might want to make the logic more complex, e.g. stop attempting after N failed attempts. See [this issue](https://github.com/t4t5/nostr-react/issues/8#issuecomment-1396374993) for my longer discussion.