### PR TITLE
core: restart relays connection when relaysUrl is updated

### DIFF
--- a/src/core.tsx
+++ b/src/core.tsx
@@ -83,7 +83,7 @@ export function NostrProvider({
         log(debug, "error", `❌ nostr (${relayUrl}): Connection error!`)
       })
     })
-  }, [])
+  }, [debug, onConnectCallback, onDisconnectCallback, relayUrls])
 
   useEffect(() => {
     // Make sure we only start the relays once (even in strict-mode)
@@ -91,7 +91,7 @@ export function NostrProvider({
       isFirstRender.current = false
       connectToRelays()
     }
-  }, [])
+  }, [connectToRelays])
 
   const publish = (event: NostrEvent) => {
     return connectedRelays.map((relay) => {

--- a/src/core.tsx
+++ b/src/core.tsx
@@ -55,43 +55,62 @@ export function NostrProvider({
 }) {
   const [isLoading, setIsLoading] = useState(true)
   const [connectedRelays, setConnectedRelays] = useState<Relay[]>([])
+  const [relays, setRelays] = useState<Relay[]>([])
+  const relayUrlsRef = useRef<string[]>([])
 
   let onConnectCallback: null | OnConnectFunc = null
   let onDisconnectCallback: null | OnDisconnectFunc = null
 
-  const isFirstRender = useRef(true)
+  const disconnectToRelays = useCallback(
+    (relayUrls: string[]) => {
+      relayUrls.forEach(
+        async (relayUrl) =>
+          await relays.find((relay) => relay.url === relayUrl)?.close(),
+      )
+      setRelays([])
+    },
+    [relays],
+  )
 
-  const connectToRelays = useCallback(() => {
-    relayUrls.forEach(async (relayUrl) => {
-      const relay = relayInit(relayUrl)
-      relay.connect()
+  const connectToRelays = useCallback(
+    (relayUrls: string[]) => {
+      relayUrls.forEach(async (relayUrl) => {
+        const relay = relayInit(relayUrl)
+        setRelays((prev) => uniqBy([...prev, relay], "url"))
+        relay.connect()
 
-      relay.on("connect", () => {
-        log(debug, "info", `✅ nostr (${relayUrl}): Connected!`)
-        setIsLoading(false)
-        onConnectCallback?.(relay)
-        setConnectedRelays((prev) => uniqBy([...prev, relay], "url"))
+        relay.on("connect", () => {
+          log(debug, "info", `✅ nostr (${relayUrl}): Connected!`)
+          setIsLoading(false)
+          onConnectCallback?.(relay)
+          setConnectedRelays((prev) => uniqBy([...prev, relay], "url"))
+        })
+
+        relay.on("disconnect", () => {
+          log(debug, "warn", `🚪 nostr (${relayUrl}): Connection closed.`)
+          onDisconnectCallback?.(relay)
+          setConnectedRelays((prev) => prev.filter((r) => r.url !== relayUrl))
+        })
+
+        relay.on("error", () => {
+          log(debug, "error", `❌ nostr (${relayUrl}): Connection error!`)
+        })
       })
-
-      relay.on("disconnect", () => {
-        log(debug, "warn", `🚪 nostr (${relayUrl}): Connection closed.`)
-        onDisconnectCallback?.(relay)
-        setConnectedRelays((prev) => prev.filter((r) => r.url !== relayUrl))
-      })
-
-      relay.on("error", () => {
-        log(debug, "error", `❌ nostr (${relayUrl}): Connection error!`)
-      })
-    })
-  }, [debug, onConnectCallback, onDisconnectCallback, relayUrls])
+    },
+    [debug, onConnectCallback, onDisconnectCallback],
+  )
 
   useEffect(() => {
-    // Make sure we only start the relays once (even in strict-mode)
-    if (isFirstRender.current) {
-      isFirstRender.current = false
-      connectToRelays()
+    if (relayUrlsRef.current === relayUrls) {
+      // relayUrls isn't updated, skip
+      return
     }
-  }, [connectToRelays])
+
+    disconnectToRelays(relayUrlsRef.current)
+    connectToRelays(relayUrls)
+
+    relayUrlsRef.current = relayUrls
+  }, [relayUrls, connectToRelays, disconnectToRelays])
 
   const publish = (event: NostrEvent) => {
     return connectedRelays.map((relay) => {


### PR DESCRIPTION
Actually, we can't connect with different relays when we update directly `relaysUrl` props of `Provider`.

With this modification, `connectToRelays()` is only triggered if `relaysUrl` change, this means that we can dynamically update the relay list from the provider.

For example :
```typescript
const CustomProvider = observer(({ children }) => {
  const { userStore } = useStores();

    return (
      <NostrProvider relayUrls={userStore.relays} debug={true}>
        {children}
      </NostrProvider>
    );

  return <>{children}</>;
});
```

If the value of `userStore.relays` is updated, the provider will automatically reconnect to the new relays.