### PR TITLE
Pass in dynamic callbacks

### DIFF
--- a/src/core.tsx
+++ b/src/core.tsx
@@ -128,9 +128,15 @@ export function useNostr() {
 export function useNostrEvents({
   filter,
   enabled = true,
+  onEvent,
+  onDone,
+  onSubscribe,
 }: {
   filter: Filter
   enabled?: boolean
+  onEvent?: OnEventFunc
+  onDone?: OnDoneFunc
+  onSubscribe?: OnSubscribeFunc
 }) {
   const {
     isLoading: isLoadingProvider,
@@ -145,9 +151,11 @@ export function useNostrEvents({
     return
   })
 
-  let onEventCallback: null | OnEventFunc = null
-  let onSubscribeCallback: null | OnSubscribeFunc = null
-  let onDoneCallback: null | OnDoneFunc = null
+  const onEventCallback: OnEventFunc = useCallback(onEvent, [onEvent])
+  const onSubscribeCallback: OnSubscribeFunc = useCallback(onSubscribe, [
+    onSubscribe,
+  ])
+  const onDoneCallback: OnDoneFunc = useCallback(onDone, [onDone])
 
   // Lets us detect changes in the nested filter object for the useEffect hook
   const filterBase64 =
@@ -226,20 +234,5 @@ export function useNostrEvents({
     onConnect,
     connectedRelays,
     unsubscribe,
-    onSubscribe: (_onSubscribeCallback: OnSubscribeFunc) => {
-      if (_onSubscribeCallback) {
-        onSubscribeCallback = _onSubscribeCallback
-      }
-    },
-    onEvent: (_onEventCallback: OnEventFunc) => {
-      if (_onEventCallback) {
-        onEventCallback = _onEventCallback
-      }
-    },
-    onDone: (_onDoneCallback: OnDoneFunc) => {
-      if (_onDoneCallback) {
-        onDoneCallback = _onDoneCallback
-      }
-    },
   }
 }


### PR DESCRIPTION
I was attempting to use the `onEvent` callback of the `useNostrEvents` hook, and ran into an issue where the callback cannot be updated. This was problematic, as my callback depended on my component's state, which changed over time. I successfully registered the callback, but as the callback was redefined on each render cycle, the `useNostrEvents` hook continued to use the initial callback that was referencing stale data.

The solution I came up with was to monitor the `events` array returned by `useNostrEvents`, and execute my callback on each new event that came in. Another approach that may work here is to allow the callback to be dynamically updated. This PR makes a change that may facilitate that.

I still need to test out this change to verify it is working as expected.